### PR TITLE
feat(backfill): map old curator name to new name

### DIFF
--- a/curation-migration-backfill/mapCurator.spec.ts
+++ b/curation-migration-backfill/mapCurator.spec.ts
@@ -2,7 +2,12 @@ import { getCurator } from './mapCurator';
 
 describe('curator unit test', () => {
   it('returns sso curatorName for old readitla-tmp curator name', () => {
-    let expected = 'trunge';
+    let expected = 'ad|Mozilla-LDAP|trunge';
     expect(getCurator('tillrunge')).toBe(expected);
+  });
+
+  it('returns sso curatorName for old readitla-tmp curator name', () => {
+    let expected = 'ad|Mozilla-LDAP|unknown';
+    expect(getCurator('non-existent')).toBe(expected);
   });
 });

--- a/curation-migration-backfill/mapCurator.ts
+++ b/curation-migration-backfill/mapCurator.ts
@@ -14,5 +14,8 @@ enum Curator {
 }
 
 export function getCurator(oldCuratorName: string) {
-  return Curator[oldCuratorName];
+  if (Curator[oldCuratorName] == undefined) {
+    return `ad|Mozilla-LDAP|unknown`;
+  }
+  return `ad|Mozilla-LDAP|${Curator[oldCuratorName]}`;
 }


### PR DESCRIPTION
## Goal 

map old curator name to new name

mapping: https://pocket.slack.com/archives/C03QVL4SU/p1647304424893189?thread_ts=1647303461.593569&cid=C03QVL4SU

- return as `ad|Mozilla-LDAP|<ssoId>` for valid case
- return as `ad|Mozilla-LDAP|<unknown>` for invalid case (verified it won't happen). if any data pass through, we can catch it and skip it for mutation

Ticket: https://getpocket.atlassian.net/browse/INFRA-382
