### PR TITLE
fix: epoch to date string day padding

### DIFF
--- a/curation-migration-backfill/lib.spec.ts
+++ b/curation-migration-backfill/lib.spec.ts
@@ -45,11 +45,19 @@ describe('lib', () => {
   });
 
   describe('epochToDateString: should convert to YYYY-MM-DD UTC', () => {
-    it('works for for zero-padded months', async () => {
+    it('works for for zero-padded months', () => {
       const date = 1647042571; // 2022-03-11 23:49:31 UTC
       expect(epochToDateString(date)).toEqual('2022-03-11');
     });
-    it('works for two-digit months', async () => {
+    it('works for two-digit months', () => {
+      const date = 1671032431; // 2022-12-14 15:40:31 UTC
+      expect(epochToDateString(date)).toEqual('2022-12-14');
+    });
+    it('works for zero-padded days', () => {
+      const date = 1646162014; // 2022-03-01 11:13:34 UTC
+      expect(epochToDateString(date)).toEqual('2022-03-01');
+    });
+    it('works for two-digit days', () => {
       const date = 1671032431; // 2022-12-14 15:40:31 UTC
       expect(epochToDateString(date)).toEqual('2022-12-14');
     });

--- a/curation-migration-backfill/lib.ts
+++ b/curation-migration-backfill/lib.ts
@@ -75,8 +75,8 @@ export function epochToDateString(epoch: number): string {
   const date = new Date(epoch * 1000);
   const month = date.getUTCMonth() + 1; // zero-indexed
   const padMonthString = month.toString().padStart(2, '0');
-  const day = date.getUTCDate().toString().padStart(2, '0');
-  return `${date.getUTCFullYear()}-${padMonthString}-${day}`;
+  const padDayString = date.getUTCDate().toString().padStart(2, '0');
+  return `${date.getUTCFullYear()}-${padMonthString}-${padDayString}`;
 }
 
 /**


### PR DESCRIPTION
Ensure single-digit days are padded in the
date string.


NVM, I didn't pull :) https://github.com/Pocket/curation-tools-data-sync/pull/90
