### PR TITLE
feat: allowlist of feeds to sync

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -21,5 +21,6 @@ export const config = {
   },
   datasyncLambda: {
     dbSecretId: `${name}/${environment}/DatabaseCredentials`,
+    allowFeeds: 'SANDBOX', // comma-separated list of scheduledSurfaceGUID to sync
   },
 };

--- a/.aws/src/datasyncLambda.ts
+++ b/.aws/src/datasyncLambda.ts
@@ -144,6 +144,7 @@ export class DatasyncLambda extends Resource {
           PARSER_ENDPOINT: parserEndpoint,
           ENVIRONMENT:
             config.environment === 'Prod' ? 'production' : 'development',
+          ALLOW_FEEDS: config.datasyncLambda.allowFeeds,
         },
         executionPolicyStatements: [
           {

--- a/curation-migration-datasync/config.ts
+++ b/curation-migration-datasync/config.ts
@@ -12,6 +12,11 @@ const config = {
       dsn: process.env.SENTRY_DSN || '',
       release: process.env.GIT_SHA || '',
     },
+    // Use this to add feeds to allowlist, e.g. 'NEW_TAB_EN_US'
+    // only events for this scheduled surface will be processed
+    allowedScheduledSurfaceGuids: process.env.ALLOW_FEEDS
+      ? process.env.ALLOW_FEEDS.split(',')
+      : ['SANDBOX'], // Default to the test feed
   },
   aws: {
     region: process.env.REGION || 'us-east-1',

--- a/curation-migration-datasync/index.ts
+++ b/curation-migration-datasync/index.ts
@@ -3,8 +3,23 @@ import * as Sentry from '@sentry/serverless';
 import { readClient, writeClient } from './dbClient';
 
 export async function handlerFn(event: any) {
-  Sentry.captureMessage(JSON.stringify(event));
   console.log(JSON.stringify(event));
+  // Check if the feed is included in the allowlist
+  if (
+    event.detail.scheduledSurfaceGuid &&
+    !config.app.allowedScheduledSurfaceGuids.includes(
+      event.detail.scheduledSurfaceGuid
+    )
+  ) {
+    console.log(
+      `Unhandled scheduledSurfaceGuid: ${event.detail.scheduledSurfaceGuid}. Skipping sync.`
+    );
+    return;
+  }
+  // TODO: INFRA-401
+  // update-approved-item events will not have scheduledSurfaceGuid; this
+  // validation must be performed when checking to see if the underlying
+  // approved item in the event is scheduled
 
   const readQuery = await (await readClient()).raw("SELECT 'Are we good?'");
   const writeQuery = await (


### PR DESCRIPTION
## Goal
Implement allowlist for the data sync lambda, based on scheduledSurfaceGUID. 

- Add allowlist to environment variables
- Default to 'SANDBOX'

## I'd love feedback/perspectives on:
- 

## Implementation Decisions
- I didn't separate this and make a unit test, but I can
- I made a note, but did not attempt to do the additional check logic required for 401

## Deployment steps
- [ ] Database migrations?
- [ ] Secrets?
- [ ] **FOR POCKET DEVELOPERS ONLY** - Post in [\#changelog](https://pocket.slack.com/archives/C0Q4UFMDZ):
> Write a #changelog message using our [best practices](https://docs.google.com/document/d/1oEt8Mtkp-6Xz9S2zaNX1EIXfQIEDN2JpY0diuPc1HZc/edit) if this PR (potentially) impacts users. Describe the 'why' and 'what'. @mention relevant teams. Link to this PR.

## References

JIRA ticket:
* [INFRA-358]


[INFRA-358]: https://getpocket.atlassian.net/browse/INFRA-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ