### PR TITLE
fix(backfill):  mutation response types to match with the updated schema

### DIFF
--- a/curation-migration-backfill/externalCaller/importMutationCaller.ts
+++ b/curation-migration-backfill/externalCaller/importMutationCaller.ts
@@ -1,4 +1,7 @@
-import { CorpusInput } from '../types';
+import {
+  CorpusInput,
+  ImportApprovedCorpusItemMutationResponse,
+} from '../types';
 import { backOff } from 'exponential-backoff';
 import { importApprovedCorpusItem } from './curatedCorpusApiCaller';
 
@@ -7,7 +10,9 @@ import { importApprovedCorpusItem } from './curatedCorpusApiCaller';
  * and calls the importApprovedCorpusItem function. Catches and throws any errors
  * as well as errors thrown by the mutation call
  */
-export async function callImportMutation(data: CorpusInput) {
+export async function callImportMutation(
+  data: CorpusInput
+): Promise<ImportApprovedCorpusItemMutationResponse> {
   // we've set the default number of retries to 3
   const backOffOptions = {
     numOfAttempts: 3,

--- a/curation-migration-backfill/index.spec.ts
+++ b/curation-migration-backfill/index.spec.ts
@@ -5,7 +5,6 @@ import sinon from 'sinon';
 import nock from 'nock';
 import config from './config';
 import { SQSEvent } from 'aws-lambda';
-import * as ImportMutationCaller from './externalCaller/importMutationCaller';
 import * as ProspectApi from './externalCaller/prospectApiCaller';
 import * as curatedItemIdMapper from './dynamodb/curatedItemIdMapper';
 
@@ -64,7 +63,7 @@ describe('curation migration', () => {
         .post('/') //curated-corpus-api call for first event
         .reply(200, {
           data: {
-            importApprovedCuratedCorpusItem: {
+            importApprovedCorpusItem: {
               approvedItem: {
                 externalId: 'random-approvedItem-guid',
               },
@@ -146,21 +145,36 @@ describe('curation migration', () => {
         })
       );
 
-      sinon.stub(ImportMutationCaller, 'callImportMutation').returns(
-        Promise.resolve({
+      //nock the curatedCorpusApi call
+      nock(config.AdminApi)
+        .post('/') //curated-corpus-api call for first event
+        .reply(200, {
           data: {
-            importApprovedCuratedCorpusItem: {
+            importApprovedCorpusItem: {
               approvedItem: {
                 externalId: 'random-approvedItem-guid',
               },
               scheduledItem: {
                 externalId: 'random-scheduledItem-guid',
-                scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+                scheduledSurfaceGuid: 'new_tab_en_us',
               },
             },
           },
         })
-      );
+        .post('/') //curated-corpus-api call for first event
+        .reply(200, {
+          data: {
+            importApprovedCorpusItem: {
+              approvedItem: {
+                externalId: 'random-approvedItem-guid',
+              },
+              scheduledItem: {
+                externalId: 'random-scheduledItem-guid',
+                scheduledSurfaceGuid: 'new_tab_en_us',
+              },
+            },
+          },
+        });
 
       // create two fake sqs events
       const fakeEvent = {

--- a/curation-migration-backfill/index.ts
+++ b/curation-migration-backfill/index.ts
@@ -32,15 +32,15 @@ export async function handlerFn(event: SQSEvent): Promise<SQSBatchResponse> {
       const curatedItemRecord: CuratedItemRecord = {
         curatedRecId: parseInt(message.curated_rec_id),
         scheduledItemExternalId:
-          importMutationResponse?.data?.importApprovedCuratedCorpusItem
-            .scheduledItem.externalId,
+          importMutationResponse?.data?.importApprovedCorpusItem.scheduledItem
+            .externalId,
         approvedItemExternalId:
-          importMutationResponse?.data?.importApprovedCuratedCorpusItem
-            .approvedItem.externalId,
+          importMutationResponse?.data?.importApprovedCorpusItem.approvedItem
+            .externalId,
         scheduledSurfaceGuid:
           ScheduledSurfaceGuid[
-            importMutationResponse?.data?.importApprovedCuratedCorpusItem
-              .scheduledItem.scheduledSurfaceGuid
+            importMutationResponse?.data?.importApprovedCorpusItem.scheduledItem
+              .scheduledSurfaceGuid
           ],
         lastUpdatedAt: new Date().getTime(),
       };

--- a/curation-migration-backfill/index.ts
+++ b/curation-migration-backfill/index.ts
@@ -17,13 +17,19 @@ import { dbClient } from './dynamodb/dynamoDbClient';
 export async function handlerFn(event: SQSEvent): Promise<SQSBatchResponse> {
   // Not using map since we want to block after each record
   const batchFailures: SQSBatchItemFailure[] = [];
-  let messageForError;
+  let curatedRecId;
+  let resolvedUrl;
+  let imageUrl;
+  let resolvedId;
   for await (const record of event.Records) {
     try {
       const message: BackfillMessage = JSON.parse(record.body);
-      //assigning inside try instead of parsing in catch,
-      //so we don't throw error if json parsing fails.
-      messageForError = message;
+      //as json stringify could throw error in catch, which can cause entire batch failure
+      // fetching this value in try, and using them in catch.
+      curatedRecId = message.curated_rec_id;
+      resolvedUrl = message.resolved_url;
+      resolvedId = message.resolved_id;
+      imageUrl = message.image_src;
       const prospectData = await fetchProspectData(message.resolved_url);
       const corpusInput = hydrateCorpusInput(message, prospectData);
       // Wait a sec... don't barrage the api. We're just backfilling here.
@@ -48,11 +54,13 @@ export async function handlerFn(event: SQSEvent): Promise<SQSBatchResponse> {
 
       await insertCuratedItem(dbClient, curatedItemRecord);
     } catch (error) {
-      console.log(`unable to process message -> ${messageForError}`);
+      console.log(`unable to process message -> curatedRecId: ${curatedRecId},
+       resolvedUrl : ${resolvedUrl}, resolvedId: ${resolvedId} image_src: ${imageUrl}`);
       console.log(error);
       Sentry.captureException(error);
       Sentry.addBreadcrumb({
-        message: `failed to process the message: ${messageForError}`,
+        message: `unable to process message -> curatedRecId: ${curatedRecId},
+       resolvedUrl : ${resolvedUrl}, resolvedId: ${resolvedId} image_src: ${imageUrl}`,
       });
       batchFailures.push({ itemIdentifier: record.messageId });
     }

--- a/curation-migration-backfill/types.ts
+++ b/curation-migration-backfill/types.ts
@@ -80,13 +80,13 @@ export type ScheduledItem = {
   scheduledDate: Date;
 };
 
-export type ImportApprovedCuratedCorpusItemPayload = {
+export type ImportApprovedCorpusItemPayload = {
   approvedItem: ApprovedItem;
   scheduledItem: ScheduledItem;
 };
 
-export interface ImportApprovedCuratedCorpusItemMutationResponse {
+export interface ImportApprovedCorpusItemMutationResponse {
   data: {
-    importApprovedCuratedCorpusItem: ImportApprovedCuratedCorpusItemPayload;
+    importApprovedCorpusItem: ImportApprovedCorpusItemPayload;
   };
 }


### PR DESCRIPTION
## Goal
mutation response types to match with the updated schema

## Implementation Decisions
- in the test-drill, the dynamo inserts are failing coz the our `data` in the response was reflecting the old schema names. updated them to reflect the new schema name.
- added more detailed breadcrumbs, prevented using `json.stringify(message)` in the `catch` block coz if stringify throws an error, it would send the entire batch message to DLQ. 

## References

JIRA ticket:
https://getpocket.atlassian.net/browse/INFRA-339
