### PR TITLE
feat(datasync-dynamo): add approvedItem externalId as a GSI

### DIFF
--- a/.aws/src/dynamoDb.ts
+++ b/.aws/src/dynamoDb.ts
@@ -49,17 +49,25 @@ export class DynamoDB extends Resource {
             type: 'S',
           },
           {
+            // externalId of the approvedItem table in curatedCorpusApi
+            name: 'approvedItemExternalId',
+            type: 'S',
+          },
+          {
             // last updated unix timestamp, incase we need to filter by last updated date (for rollbacks)
             name: 'lastUpdatedAt',
             type: 'N',
           },
         ],
-        //for curatedItem datasync - we will get the externalId of the scheduledItems
-        // then we can retrieve curatedRecId from this index
         globalSecondaryIndex: [
           {
             name: 'scheduledItemExternalId-GSI',
             hashKey: 'scheduledItemExternalId',
+            projectionType: 'ALL',
+          },
+          {
+            name: 'approvedItemExternalId-GSI',
+            hashKey: 'approvedItemExternalId',
             projectionType: 'ALL',
           },
           {

--- a/.docker/localstack/dynamodb/curation_migration_table.json
+++ b/.docker/localstack/dynamodb/curation_migration_table.json
@@ -16,6 +16,10 @@
       "AttributeType": "S"
     },
     {
+      "AttributeName": "approvedItemExternalId",
+      "AttributeType": "S"
+    },
+    {
       "AttributeName": "scheduledSurfaceGuid",
       "AttributeType": "S"
     },
@@ -30,6 +34,22 @@
       "KeySchema": [
         {
           "AttributeName": "scheduledItemExternalId",
+          "KeyType": "HASH"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "ALL"
+      },
+      "ProvisionedThroughput": {
+        "ReadCapacityUnits": 5,
+        "WriteCapacityUnits": 5
+      }
+    },
+    {
+      "IndexName": "approvedItemExternalId-GSI",
+      "KeySchema": [
+        {
+          "AttributeName": "approvedItemExternalId",
           "KeyType": "HASH"
         }
       ],

--- a/curation-migration-datasync/dynamodb/curatedItemRecordModel.integration.ts
+++ b/curation-migration-datasync/dynamodb/curatedItemRecordModel.integration.ts
@@ -37,6 +37,13 @@ describe('dynamodb read and write test', () => {
       approvedItemExternalId: 'random-approved-guid-4',
       lastUpdatedAt: timestamp2,
     },
+    {
+      curatedRecId: 5,
+      scheduledSurfaceGuid: ScheduledSurfaceGuid.NEW_TAB_DE_DE,
+      scheduledItemExternalId: 'random-scheduled-guid-5',
+      approvedItemExternalId: 'random-approved-guid-4',
+      lastUpdatedAt: timestamp1,
+    },
   ];
 
   beforeAll(async () => {
@@ -113,6 +120,29 @@ describe('dynamodb read and write test', () => {
       ScheduledSurfaceGuid.NEW_TAB_EN_GB
     );
     expect(res?.[0].lastUpdatedAt).toEqual(timestamp2);
+  });
+
+  it('should get all curatedItemRecords matching with approvedItemexternalId', async () => {
+    const res: CuratedItemRecord[] =
+      await curatedItemModel.getByApprovedItemExternalId(
+        'random-approved-guid-4'
+      );
+    expect(res).not.toBeUndefined();
+    expect(res.length).toEqual(2);
+    expect(res?.[0].curatedRecId).toEqual(5);
+    expect(res?.[0].scheduledItemExternalId).toEqual('random-scheduled-guid-5');
+    expect(res?.[0].approvedItemExternalId).toEqual('random-approved-guid-4');
+    expect(res?.[0].scheduledSurfaceGuid).toEqual(
+      ScheduledSurfaceGuid.NEW_TAB_DE_DE
+    );
+    expect(res?.[0].lastUpdatedAt).toEqual(timestamp1);
+    expect(res?.[1].curatedRecId).toEqual(4);
+    expect(res?.[1].scheduledItemExternalId).toEqual('random-scheduled-guid-4');
+    expect(res?.[1].approvedItemExternalId).toEqual('random-approved-guid-4');
+    expect(res?.[1].scheduledSurfaceGuid).toEqual(
+      ScheduledSurfaceGuid.NEW_TAB_EN_GB
+    );
+    expect(res?.[1].lastUpdatedAt).toEqual(timestamp2);
   });
 
   it('should delete a single record from the dynamo db', async () => {

--- a/curation-migration-datasync/dynamodb/curatedItemRecordModel.integration.ts
+++ b/curation-migration-datasync/dynamodb/curatedItemRecordModel.integration.ts
@@ -46,7 +46,7 @@ describe('dynamodb read and write test', () => {
     },
   ];
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     await truncateDynamoDb(dbClient);
 
     const insertRecord = curatedItemRecords.map(async (item) => {
@@ -55,7 +55,7 @@ describe('dynamodb read and write test', () => {
     await Promise.all(insertRecord);
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await truncateDynamoDb(dbClient);
   });
 

--- a/curation-migration-datasync/dynamodb/curatedItemRecordModel.ts
+++ b/curation-migration-datasync/dynamodb/curatedItemRecordModel.ts
@@ -67,6 +67,52 @@ export class CuratedItemRecordModel {
   }
 
   /**
+   * retrieves list of curatedItem by approvedItemExternalId
+   * Note: we have 1:N mapping of approvedItem externalId and curated_rec_id
+   * @param approvedItemExternalId approvedItem's externalId
+   */
+  public async getByApprovedItemExternalId(
+    approvedItemExternalId: string
+  ): Promise<CuratedItemRecord[]> {
+    const input: QueryCommandInput = {
+      TableName: config.aws.dynamoDB.curationMigrationTable,
+      IndexName: 'approvedItemExternalId-GSI',
+      KeyConditionExpression:
+        'approvedItemExternalId = :approvedItemExternalId',
+      ExpressionAttributeValues: {
+        ':approvedItemExternalId': approvedItemExternalId,
+      },
+    };
+    const res: QueryCommandOutput = await this.client.send(
+      new QueryCommand(input)
+    );
+
+    //this must always be false coz we are expecting only one item per record.
+    //if this gets thrown, we need to investigate the bug
+    if (res.LastEvaluatedKey) {
+      Sentry.captureMessage(
+        `method 'getByApprovedItemExternalId' called with '${approvedItemExternalId}'
+       has multiple pages of results that we are not handling!`
+      );
+    }
+
+    if (res.Items?.length) {
+      return res.Items.map((item): CuratedItemRecord => {
+        // force type safety
+        return {
+          curatedRecId: item.curatedRecId,
+          scheduledSurfaceGuid: item.scheduledSurfaceGuid,
+          scheduledItemExternalId: item.scheduledItemExternalId,
+          approvedItemExternalId: item.approvedItemExternalId,
+          lastUpdatedAt: item.lastUpdatedAt,
+        };
+      });
+    } else {
+      return [];
+    }
+  }
+
+  /**
    * retrieves items by scheduledSurfaceGuid
    * @param scheduledSurfaceGuid
    * @returns CuratedItemRecord matching curated items

--- a/curation-migration-datasync/dynamodb/curatedItemRecordModel.ts
+++ b/curation-migration-datasync/dynamodb/curatedItemRecordModel.ts
@@ -96,20 +96,7 @@ export class CuratedItemRecordModel {
       );
     }
 
-    if (res.Items?.length) {
-      return res.Items.map((item): CuratedItemRecord => {
-        // force type safety
-        return {
-          curatedRecId: item.curatedRecId,
-          scheduledSurfaceGuid: item.scheduledSurfaceGuid,
-          scheduledItemExternalId: item.scheduledItemExternalId,
-          approvedItemExternalId: item.approvedItemExternalId,
-          lastUpdatedAt: item.lastUpdatedAt,
-        };
-      });
-    } else {
-      return [];
-    }
+    return res.Items as CuratedItemRecord[];
   }
 
   /**
@@ -144,20 +131,7 @@ export class CuratedItemRecordModel {
       );
     }
 
-    if (res.Items?.length) {
-      return res.Items.map((item): CuratedItemRecord => {
-        // force type safety
-        return {
-          curatedRecId: item.curatedRecId,
-          scheduledSurfaceGuid: item.scheduledSurfaceGuid,
-          scheduledItemExternalId: item.scheduledItemExternalId,
-          approvedItemExternalId: item.approvedItemExternalId,
-          lastUpdatedAt: item.lastUpdatedAt,
-        };
-      });
-    } else {
-      return [];
-    }
+    return res.Items as CuratedItemRecord[];
   }
 
   /**
@@ -176,7 +150,6 @@ export class CuratedItemRecordModel {
     };
 
     const res = await this.client.send(new GetCommand(input));
-
     return {
       curatedRecId: res.Item?.curatedRecId,
       scheduledSurfaceGuid: res.Item?.scheduledSurfaceGuid,


### PR DESCRIPTION
## Goal
Add approvedItem's externalId as a global secondary index

### implementation decisions/feedback on:
- did not add pagination feature as we don't expect one approvedItem's data go beyond 1MB. 
- re-create test env between test, otherwise the newly added test fails. 

#### TODOs:
- follow up PR - to consume update-approved-item event. 

JIRA ticket: 
https://getpocket.atlassian.net/browse/INFRA-401
