### PR TITLE
fix(scheduledItemPayload): createdAt and updatedAt are set to utcTime…

### DIFF
--- a/curation-migration-datasync/database/dataService.integration.ts
+++ b/curation-migration-datasync/database/dataService.integration.ts
@@ -29,9 +29,9 @@ describe('database integration test', function () {
     imageUrl: 'https://some-s3-url.com',
     topic: 'HEALTH_FITNESS',
     isSyndicated: false,
-    createdAt: 1648593897,
+    createdAt: 'Fri, 01 Apr 2022 21:55:15 GMT', //1648850115
+    updatedAt: 'Sat, 02 Apr 2022 21:55:15 GMT', //1648936515
     createdBy: 'ad|Mozilla-LDAP|sri',
-    updatedAt: 1648593897,
     scheduledSurfaceGuid: 'NEW_TAB_EN_US',
     scheduledDate: '2022-03-25',
   };

--- a/curation-migration-datasync/database/hydrator.ts
+++ b/curation-migration-datasync/database/hydrator.ts
@@ -8,6 +8,7 @@ import {
 } from '../types';
 import {
   convertDateToTimestamp,
+  convertUtcStringToTimestamp,
   getCuratorNameFromSso,
 } from '../helpers/dataTransformers';
 
@@ -42,8 +43,8 @@ export function hydrateCuratedFeedProspectItem(
     type: null,
     status: 'ready',
     curator: getCuratorNameFromSso(eventBody.createdBy),
-    time_added: eventBody.createdAt,
-    time_updated: eventBody.updatedAt,
+    time_added: convertUtcStringToTimestamp(eventBody.createdAt),
+    time_updated: convertUtcStringToTimestamp(eventBody.updatedAt),
     top_domain_id: topDomainId,
     title: eventBody.title,
     excerpt: eventBody.excerpt,

--- a/curation-migration-datasync/helpers/dataTransformers.ts
+++ b/curation-migration-datasync/helpers/dataTransformers.ts
@@ -25,3 +25,13 @@ export function getCuratorNameFromSso(ssoName: string): string {
   }
   return ssoName.substring(prefix.length);
 }
+
+/***
+ * converts utc string to timestamp
+ * @param utcString e.g Sat, 01 Apr 2022 21:55:15 GMT
+ * @returns epoc timestamp e.g 1648936515
+ */
+export function convertUtcStringToTimestamp(utcString: string): number {
+  const dt = new Date(utcString).getTime();
+  return dt / 1000;
+}

--- a/curation-migration-datasync/types.ts
+++ b/curation-migration-datasync/types.ts
@@ -10,9 +10,9 @@ export type ScheduledItemPayload = {
   imageUrl: string;
   topic: string;
   isSyndicated: boolean;
-  createdAt: number;
+  createdAt: string;
   createdBy: string;
-  updatedAt: number;
+  updatedAt: string;
   scheduledSurfaceGuid: string;
   scheduledDate: string;
 };


### PR DESCRIPTION
## Goal
createdAt and updatedAt are set to utcTimestamp, we need to convert to epoc timestamp before setting them in database.

e.g event from eventBridge -> 
`"createdAt":"Mon, 04 Apr 2022 21:55:15 GMT","createdBy":"ad|Mozilla-LDAP|kschelonka","updatedAt":"Mon, 04 Apr 2022 21:55:15 GMT","scheduledSurfaceGuid":"SANDBOX","scheduledDate":"2022-04-05"}}`

### Implementation decisions:
- changed the createdAt and updatedAt type to `string` ScheduledItemPayload`
- function to convert utcString to epoc timestamp, use them in hydrator.ts
- function unit tested in this PR: https://github.com/Pocket/curation-tools-data-sync/blob/1ff91f73e8c57ed3b23027120223d3f62eb4026a/curation-migration-datasync/helpers/dataTransformers.spec.ts#L30
- fix all integration test to convert utcTimestamp->epoc in the test


Ticket: https://getpocket.atlassian.net/browse/INFRA-415