### PR TITLE
feat(queue-loader-rollback): rollback script for queue-loader-script 

### DIFF
--- a/bin/db.ts
+++ b/bin/db.ts
@@ -1,0 +1,25 @@
+import knex from 'knex';
+
+const connection = {
+  host: process.env.DB_HOST || '<host>',
+  user: process.env.DB_USER || '<user>',
+  password: process.env.DB_PASSWORD || '<password>',
+  port: 3306,
+  database: 'readitla_ril-tmp',
+  charset: 'utf8mb4',
+};
+
+export const dbClient = knex({
+  client: 'mysql',
+  connection,
+  pool: {
+    /**
+     * Explicitly set the session timezone. We don't want to take any chances with this
+     */
+    afterCreate: (connection, callback) => {
+      connection.query(`SET time_zone = 'US/Central';`, (err) => {
+        callback(err, connection);
+      });
+    },
+  },
+});

--- a/bin/package.json
+++ b/bin/package.json
@@ -4,7 +4,8 @@
   "description": "Temporary script to move queued items to the curated_feed_items table",
   "main": "load-queued-items.js",
   "scripts": {
-    "load": "ts-node load-queued-items.ts"
+    "load": "ts-node load-queued-items.ts",
+    "rollback": "ts-node rollback-queued-items.ts"
   },
   "author": "",
   "license": "ISC",

--- a/bin/rollback-queued-items.ts
+++ b/bin/rollback-queued-items.ts
@@ -1,0 +1,81 @@
+#! /usr/bin/env ts-node
+
+// 1. Get all curated feed item IDs after time_live >= timestamp and matching feed_id
+// 2. Update the status curated_feed_queued_items for the IDs from 1 to "ready" from "used"
+// 3. Delete the IDs from the tile_source table
+// 4. Delete the IDs from curated_feed_items table
+
+import { Knex } from 'knex';
+import { dbClient } from './db';
+
+async function getCuratedItemsAfterDate(feedId: number, timeLive: number) {
+  return dbClient('curated_feed_items')
+    .select('queued_id', 'curated_rec_id')
+    .where('time_live', '>=', timeLive)
+    .where('feed_id', '=', feedId);
+}
+
+async function rollbackQueuedItems(queuedIds: number[], trx: Knex.Transaction) {
+  await dbClient('curated_feed_queued_items')
+    .update({
+      status: 'ready',
+      time_updated: dbClient.raw('time_added'),
+    })
+    .where('status', '=', 'used')
+    .whereIn('queued_id', queuedIds)
+    .transacting(trx);
+}
+
+async function rollbackTileSource(
+  curatedRecIds: number[],
+  trx: Knex.Transaction
+) {
+  await dbClient('tile_source')
+    .delete()
+    .whereIn('source_id', curatedRecIds)
+    .transacting(trx);
+}
+
+async function rollbackCuratedItems(
+  curatedRecIds: number[],
+  trx: Knex.Transaction
+) {
+  return trx('curated_feed_items')
+    .delete()
+    .whereIn('curated_rec_id', curatedRecIds);
+}
+
+async function rollback() {
+  const feedId: number = process.argv[2] as unknown as number;
+  const timeLive: number = process.argv[3] as unknown as number;
+
+  const curatedItems = await getCuratedItemsAfterDate(feedId, timeLive);
+  const queuedIds: number[] = [];
+  const curatedRecIds: number[] = [];
+
+  for (const curatedItem of curatedItems) {
+    queuedIds.push(curatedItem['queued_id']);
+    curatedRecIds.push(curatedItem['curated_rec_id']);
+  }
+
+  return await dbClient.transaction(async (trx) => {
+    await rollbackQueuedItems(queuedIds, trx);
+    await rollbackTileSource(curatedRecIds, trx);
+    await rollbackCuratedItems(curatedRecIds, trx);
+
+    return { feedId, timeLive, curatedRecIds, queuedIds };
+  });
+}
+
+rollback()
+  .then((res) => {
+    console.log(
+      `Successfully rollback feed ID: ${res.feedId} after time_live: ${res.timeLive}`
+    );
+    console.log(`Number of items affected back: ${res.curatedRecIds.length}`);
+    console.log('Curated Rec IDs: ', JSON.stringify(res.curatedRecIds));
+    console.log('Queued IDs: ', JSON.stringify(res.curatedRecIds));
+    console.log('Done');
+    process.exit();
+  })
+  .catch((e) => console.log(e));


### PR DESCRIPTION
## Goal

Script to rollback in case of any issues with the curation data migration.
This will revert all queued items that were moved from the `curated_feed_queued_items` table to the `curated_feed_items` table

### Implementation details/feedback on:
- load script have transaction within each item. we throw an error if we not able to parse an item to investigate. question: do we prefer to continue with the rest of the queue load if one row fails? 
- rollback script gets the time we ran the load script and feed_id as input, and rolls back all the records since the time_live >= <time_we_ran_load_script>
- this way, we choose to continue with the migration or choose to rollback the entire queue-load depending on the no of rows that fails (e.g 10% failure vs 90% failure)

- tested load script and rollback script in dev db. 

## References

JIRA ticket: INFRA-455
