### PR TITLE
fix: successfully process scheduled item events when topic is set to null/empty/unknown value

### DIFF
--- a/curation-migration-datasync/database/dataService.ts
+++ b/curation-migration-datasync/database/dataService.ts
@@ -366,6 +366,10 @@ export class DataService {
    * @returns topic_id matching with the topic
    */
   public async getTopicIdByName(topic: string): Promise<number> {
+    //curated_feed_queued_items defaults to 0 if topic_id is not set.
+    if (!topic) {
+      return 0;
+    }
     const response = await this.db(config.tables.curatedFeedTopics)
       .select('topic_id')
       .where({

--- a/curation-migration-datasync/eventConsumer.integration.ts
+++ b/curation-migration-datasync/eventConsumer.integration.ts
@@ -461,6 +461,17 @@ describe('event consumption integration test', function () {
         );
       });
 
+      it('should allow to update scheduled item when topic is null', async () => {
+        testEventBody.topic = null;
+        await updateScheduledItem(testEventBody, db);
+        const queuedItemRecord = await db(config.tables.curatedFeedQueuedItems)
+          .where({ queued_id: curatedRecord.queued_id })
+          .first();
+        expect(queuedItemRecord.topic_id).toEqual(0);
+        testEventBody.topic = 'SELF_IMPROVEMENT';
+        //resets as its being used by other tests
+      });
+
       it('rolls back updates if an error occurs before all tables are updated', async () => {
         sinon.stub(hydrator, 'hydrateCuratedFeedItem').throws('error');
 

--- a/curation-migration-datasync/helpers/topicMapper.spec.ts
+++ b/curation-migration-datasync/helpers/topicMapper.spec.ts
@@ -9,16 +9,12 @@ describe('topics mapper test', () => {
     );
   });
 
-  it('should throw an error if the topic is not in the mapping', () => {
+  it('should return null for unknown topic', () => {
     const curatedCorpusTopic = 'unknown topic';
-    expect(() => getTopicForReaditLaTmpDatabase(curatedCorpusTopic)).throw(
-      'invalid topic mapping'
-    );
+    expect(getTopicForReaditLaTmpDatabase(curatedCorpusTopic)).is.null;
   });
 
-  it('should throw an error if a null topic is passed', () => {
-    expect(() => getTopicForReaditLaTmpDatabase('')).throw(
-      'topic cannot be null or empty'
-    );
+  it('should return null for null topic', () => {
+    expect(getTopicForReaditLaTmpDatabase(null)).is.null;
   });
 });

--- a/curation-migration-datasync/helpers/topicMapper.ts
+++ b/curation-migration-datasync/helpers/topicMapper.ts
@@ -18,12 +18,9 @@ enum TopicMappedToReaditlaTmpDb {
   TRAVEL = 'Travel',
 }
 
-export function getTopicForReaditLaTmpDatabase(input: string) {
-  if (!input) {
-    throw new Error('topic cannot be null or empty');
-  }
-  if (TopicMappedToReaditlaTmpDb[input] == undefined) {
-    throw new Error('invalid topic mapping');
+export function getTopicForReaditLaTmpDatabase(input: string | null) {
+  if (!input || TopicMappedToReaditlaTmpDb[input] == undefined) {
+    return null;
   }
 
   return TopicMappedToReaditlaTmpDb[input];

--- a/curation-migration-datasync/types.ts
+++ b/curation-migration-datasync/types.ts
@@ -8,7 +8,7 @@ export type ScheduledItemPayload = {
   language: string;
   publisher: string;
   imageUrl: string;
-  topic: string;
+  topic: string | null;
   isSyndicated: boolean;
   createdAt: string;
   createdBy: string;


### PR DESCRIPTION
## Goal
- to process scheduled-items in the datasync and update them successfully in the old database when topic is set as null or empty

## I'd love feedback/perspectives on:
- when the topic from events are null/empty/unknown-topic, set the event topic to null. 
- when topic is passed as `null` to `getTopicIdbyName` function, return `0`. this is the default topic_id value in curated_feed_queued_items table

Ticket: https://getpocket.atlassian.net/browse/INFRA-564

slack thread: https://pocket.slack.com/archives/CTLKW5WCF/p1652371275313049
