### PR TITLE
MC-1553: use pocket/circleci-orbs@2.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   aws-ecs: circleci/aws-ecs@2.0.0
   aws-cli: circleci/aws-cli@1.2.1
-  pocket: pocket/circleci-orbs@1.2.4
+  pocket: pocket/circleci-orbs@2.3.0
 
 # Workflow shortcuts
 # You can remove unnecessary shortcuts as applicable


### PR DESCRIPTION
# Goal

Use the new pocket/circleci-orbs@2.3.0 with the updated aws-ecr orb & build_docker job.

## Todos
- [x] deployed to dev

## Reference

Tickets:
* https://mozilla-hub.atlassian.net/browse/MC-1553